### PR TITLE
Code cleanup

### DIFF
--- a/bansa/src/main/kotlin/com/brianegan/bansa/Action.kt
+++ b/bansa/src/main/kotlin/com/brianegan/bansa/Action.kt
@@ -1,5 +1,4 @@
 package com.brianegan.bansa
 
-interface Action {
-}
+interface Action
 

--- a/bansa/src/main/kotlin/com/brianegan/bansa/RxStore.kt
+++ b/bansa/src/main/kotlin/com/brianegan/bansa/RxStore.kt
@@ -12,7 +12,7 @@ class RxStore<S : State, A : Action>(
         private val initialState: S,
         private val initialReducer: (S, A) -> S,
         private val scheduler: Scheduler = Schedulers.newThread()
-) : Store<S, A>(initialState, initialReducer, scheduler) {
+) : Store<S, A> {
     private val dispatcher: SerializedSubject<A, A>
     private var currentState: S
 
@@ -27,8 +27,7 @@ class RxStore<S : State, A : Action>(
                 .observeOn(scheduler) // Run the scan on a given thread, by default a background thread
                 .scan(currentState, { state, action -> reducer(state, action) }) // Run the action through your reducers, producing a new state
                 .doOnNext({ newState -> currentState = newState }) // Update the state field of the instance for lazy access
-                .publish() // Turn it into a ConnectableObservable so all subscribers receive the same values
-                .refCount()
+                .share() // Share the Observable so all subscribers receive the same values
 
         state.subscribe()
     }

--- a/bansa/src/main/kotlin/com/brianegan/bansa/State.kt
+++ b/bansa/src/main/kotlin/com/brianegan/bansa/State.kt
@@ -1,5 +1,3 @@
 package com.brianegan.bansa
 
-interface State {
-
-}
+interface State

--- a/bansa/src/main/kotlin/com/brianegan/bansa/Store.kt
+++ b/bansa/src/main/kotlin/com/brianegan/bansa/Store.kt
@@ -1,17 +1,12 @@
 package com.brianegan.bansa
 
 import rx.Observable
-import rx.Scheduler
 import rx.Subscriber
 import rx.Subscription
 
-abstract class Store<S : State, A : Action>(
-        private val initialState: S,
-        private val initialReducer: (S, A) -> S,
-        private val scheduler: Scheduler
-) {
-    abstract val state: Observable<S>
-    abstract fun getState(): S
-    abstract var dispatch: (action: A) -> A
-    abstract fun subscribe(subscriber: Subscriber<S>): Subscription
+interface Store<S : State, A : Action> {
+    val state: Observable<S>
+    fun getState(): S
+    var dispatch: (action: A) -> A
+    fun subscribe(subscriber: Subscriber<S>): Subscription
 }

--- a/bansa/src/main/kotlin/com/brianegan/bansa/combineReducers.kt
+++ b/bansa/src/main/kotlin/com/brianegan/bansa/combineReducers.kt
@@ -1,8 +1,6 @@
 package com.brianegan.bansa
 
-import java.util.*
-
 fun <A : Action, S> combineReducers(vararg reducers: (S, A) -> S): (S, A) -> S =
         { state: S, action: A ->
-            Arrays.asList(*reducers).fold(state, { state, reducer -> reducer(state, action) })
+            reducers.fold(state, { state, reducer -> reducer(state, action) })
         }


### PR DESCRIPTION
I cleaned some code in the main source folder.
Feel free to challenges my changes, I will update the pull request accordingly if necessary.

Changes:

- Store is now an interface instead of an abstract class
- use share() instead of publish().refCount()
- remove curly braces in empty interface definitions
- replace 'Arrays.asList(*reducers)' by just 'reducers'