### PR TITLE
Remove empty interfaces State and Action

### DIFF
--- a/bansa/src/main/kotlin/com/brianegan/bansa/Action.kt
+++ b/bansa/src/main/kotlin/com/brianegan/bansa/Action.kt
@@ -1,4 +1,0 @@
-package com.brianegan.bansa
-
-interface Action
-

--- a/bansa/src/main/kotlin/com/brianegan/bansa/RxStore.kt
+++ b/bansa/src/main/kotlin/com/brianegan/bansa/RxStore.kt
@@ -8,7 +8,7 @@ import rx.schedulers.Schedulers
 import rx.subjects.PublishSubject
 import rx.subjects.SerializedSubject
 
-class RxStore<S, A : Action>(
+class RxStore<S, A>(
         private val initialState: S,
         private val initialReducer: (S, A) -> S,
         private val scheduler: Scheduler = Schedulers.newThread()

--- a/bansa/src/main/kotlin/com/brianegan/bansa/RxStore.kt
+++ b/bansa/src/main/kotlin/com/brianegan/bansa/RxStore.kt
@@ -8,7 +8,7 @@ import rx.schedulers.Schedulers
 import rx.subjects.PublishSubject
 import rx.subjects.SerializedSubject
 
-class RxStore<S : State, A : Action>(
+class RxStore<S, A : Action>(
         private val initialState: S,
         private val initialReducer: (S, A) -> S,
         private val scheduler: Scheduler = Schedulers.newThread()

--- a/bansa/src/main/kotlin/com/brianegan/bansa/State.kt
+++ b/bansa/src/main/kotlin/com/brianegan/bansa/State.kt
@@ -1,3 +1,0 @@
-package com.brianegan.bansa
-
-interface State

--- a/bansa/src/main/kotlin/com/brianegan/bansa/Store.kt
+++ b/bansa/src/main/kotlin/com/brianegan/bansa/Store.kt
@@ -4,7 +4,7 @@ import rx.Observable
 import rx.Subscriber
 import rx.Subscription
 
-interface Store<S : State, A : Action> {
+interface Store<S, A : Action> {
     val state: Observable<S>
     fun getState(): S
     var dispatch: (action: A) -> A

--- a/bansa/src/main/kotlin/com/brianegan/bansa/Store.kt
+++ b/bansa/src/main/kotlin/com/brianegan/bansa/Store.kt
@@ -4,7 +4,7 @@ import rx.Observable
 import rx.Subscriber
 import rx.Subscription
 
-interface Store<S, A : Action> {
+interface Store<S, A> {
     val state: Observable<S>
     fun getState(): S
     var dispatch: (action: A) -> A

--- a/bansa/src/main/kotlin/com/brianegan/bansa/applyMiddleware.kt
+++ b/bansa/src/main/kotlin/com/brianegan/bansa/applyMiddleware.kt
@@ -1,6 +1,6 @@
 package com.brianegan.bansa
 
-fun <S : State, A : Action> applyMiddleware(
+fun <S, A : Action> applyMiddleware(
         vararg middleware: (Store<S, A>) -> ((A) -> A) -> (A) -> A)
         : (Store<S, A>) -> Store<S, A> {
     return { store ->

--- a/bansa/src/main/kotlin/com/brianegan/bansa/applyMiddleware.kt
+++ b/bansa/src/main/kotlin/com/brianegan/bansa/applyMiddleware.kt
@@ -1,6 +1,6 @@
 package com.brianegan.bansa
 
-fun <S, A : Action> applyMiddleware(
+fun <S, A> applyMiddleware(
         vararg middleware: (Store<S, A>) -> ((A) -> A) -> (A) -> A)
         : (Store<S, A>) -> Store<S, A> {
     return { store ->

--- a/bansa/src/main/kotlin/com/brianegan/bansa/combineReducers.kt
+++ b/bansa/src/main/kotlin/com/brianegan/bansa/combineReducers.kt
@@ -1,6 +1,6 @@
 package com.brianegan.bansa
 
-fun <A : Action, S> combineReducers(vararg reducers: (S, A) -> S): (S, A) -> S =
+fun <A, S> combineReducers(vararg reducers: (S, A) -> S): (S, A) -> S =
         { state: S, action: A ->
             reducers.fold(state, { state, reducer -> reducer(state, action) })
         }

--- a/bansa/src/main/kotlin/com/brianegan/bansa/createStore.kt
+++ b/bansa/src/main/kotlin/com/brianegan/bansa/createStore.kt
@@ -3,7 +3,7 @@ package com.brianegan.bansa
 import rx.Scheduler
 import rx.schedulers.Schedulers
 
-fun <S, A : Action> createStore(
+fun <S, A> createStore(
         initialState: S,
         reducer: (S, A) -> S,
         scheduler: Scheduler = Schedulers.newThread())

--- a/bansa/src/main/kotlin/com/brianegan/bansa/createStore.kt
+++ b/bansa/src/main/kotlin/com/brianegan/bansa/createStore.kt
@@ -3,7 +3,7 @@ package com.brianegan.bansa
 import rx.Scheduler
 import rx.schedulers.Schedulers
 
-fun <S : State, A : Action> createStore(
+fun <S, A : Action> createStore(
         initialState: S,
         reducer: (S, A) -> S,
         scheduler: Scheduler = Schedulers.newThread())

--- a/bansa/src/test/kotlin/com/brianegan/bansa/MiddlewareTest.kt
+++ b/bansa/src/test/kotlin/com/brianegan/bansa/MiddlewareTest.kt
@@ -8,7 +8,7 @@ import java.util.concurrent.TimeUnit
 
 class MiddlewareTest {
     data class MyState(val state: String = "initial state")
-    data class MyAction(val type: String = "unknown") : Action
+    data class MyAction(val type: String = "unknown")
 
     @Test
     fun `actions should be run through a store's middleware`() {

--- a/bansa/src/test/kotlin/com/brianegan/bansa/MiddlewareTest.kt
+++ b/bansa/src/test/kotlin/com/brianegan/bansa/MiddlewareTest.kt
@@ -7,7 +7,7 @@ import java.util.*
 import java.util.concurrent.TimeUnit
 
 class MiddlewareTest {
-    data class MyState(val state: String = "initial state") : State
+    data class MyState(val state: String = "initial state")
     data class MyAction(val type: String = "unknown") : Action
 
     @Test

--- a/bansa/src/test/kotlin/com/brianegan/bansa/StoreTest.kt
+++ b/bansa/src/test/kotlin/com/brianegan/bansa/StoreTest.kt
@@ -5,7 +5,7 @@ import org.junit.Test
 import rx.observers.TestSubscriber
 
 class StoreTest {
-    data class MyState(val state: String = "initial state") : State
+    data class MyState(val state: String = "initial state")
     data class MyAction(val type: String = "unknown") : Action
 
     @Test

--- a/bansa/src/test/kotlin/com/brianegan/bansa/StoreTest.kt
+++ b/bansa/src/test/kotlin/com/brianegan/bansa/StoreTest.kt
@@ -6,7 +6,7 @@ import rx.observers.TestSubscriber
 
 class StoreTest {
     data class MyState(val state: String = "initial state")
-    data class MyAction(val type: String = "unknown") : Action
+    data class MyAction(val type: String = "unknown")
 
     @Test
     fun `when an action is fired, the corresponding reducer should be called and update the state of the application`() {

--- a/bansa/src/test/kotlin/com/brianegan/bansa/createTestStore.kt
+++ b/bansa/src/test/kotlin/com/brianegan/bansa/createTestStore.kt
@@ -2,6 +2,6 @@ package com.brianegan.bansa
 
 import rx.schedulers.Schedulers
 
-fun <S, A : Action> createTestStore(initialState: S, reducer: (S, A) -> S): Store<S, A> {
+fun <S, A> createTestStore(initialState: S, reducer: (S, A) -> S): Store<S, A> {
     return createStore(initialState, reducer, Schedulers.immediate());
 }

--- a/bansa/src/test/kotlin/com/brianegan/bansa/createTestStore.kt
+++ b/bansa/src/test/kotlin/com/brianegan/bansa/createTestStore.kt
@@ -2,6 +2,6 @@ package com.brianegan.bansa
 
 import rx.schedulers.Schedulers
 
-fun <S : State, A : Action> createTestStore(initialState: S, reducer: (S, A) -> S): Store<S, A> {
+fun <S, A : Action> createTestStore(initialState: S, reducer: (S, A) -> S): Store<S, A> {
     return createStore(initialState, reducer, Schedulers.immediate());
 }

--- a/examples/counter/src/main/kotlin/com/brianegan/bansa/counter/Application.kt
+++ b/examples/counter/src/main/kotlin/com/brianegan/bansa/counter/Application.kt
@@ -1,6 +1,5 @@
 package com.brianegan.bansa.counter
 
-import com.brianegan.bansa.Action
 import com.brianegan.bansa.Store
 import com.brianegan.bansa.createStore
 import uy.kohesive.injekt.Injekt
@@ -13,12 +12,12 @@ class Application : android.app.Application() {
     companion object : InjektMain() {
         override fun InjektRegistrar.registerInjectables() {
             addSingleton(
-                    fullType<Store<ApplicationState, Action>>(),
+                    fullType<Store<ApplicationState, Any>>(),
                     createStore(ApplicationState(), counterReducer));
         }
     }
 
-    val store = Injekt.get(fullType<Store<ApplicationState, Action>>())
+    val store = Injekt.get(fullType<Store<ApplicationState, Any>>())
 
     override fun onCreate() {
         super.onCreate()

--- a/examples/counter/src/main/kotlin/com/brianegan/bansa/counter/ApplicationState.kt
+++ b/examples/counter/src/main/kotlin/com/brianegan/bansa/counter/ApplicationState.kt
@@ -1,5 +1,3 @@
 package com.brianegan.bansa.counter
 
-import com.brianegan.bansa.State
-
-data class ApplicationState(val counter: Int = 0) : State
+data class ApplicationState(val counter: Int = 0)

--- a/examples/counter/src/main/kotlin/com/brianegan/bansa/counter/CounterActions.kt
+++ b/examples/counter/src/main/kotlin/com/brianegan/bansa/counter/CounterActions.kt
@@ -1,8 +1,6 @@
 package com.brianegan.bansa.counter
 
-import com.brianegan.bansa.Action
-
-interface CounterAction : Action {}
+interface CounterAction {}
 
 sealed class CounterActions {
     object INIT : CounterAction

--- a/examples/counter/src/main/kotlin/com/brianegan/bansa/counter/RootActivity.kt
+++ b/examples/counter/src/main/kotlin/com/brianegan/bansa/counter/RootActivity.kt
@@ -2,13 +2,12 @@ package com.brianegan.bansa.counter
 
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
-import com.brianegan.bansa.Action
 import com.brianegan.bansa.Store
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
 open class RootActivity : AppCompatActivity() {
-    val store: Store<ApplicationState, Action> = Injekt.get<Store<ApplicationState, Action>>()
+    val store: Store<ApplicationState, Any> = Injekt.get<Store<ApplicationState, Any>>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/examples/counter/src/main/kotlin/com/brianegan/bansa/counter/RootView.kt
+++ b/examples/counter/src/main/kotlin/com/brianegan/bansa/counter/RootView.kt
@@ -3,7 +3,6 @@ package com.brianegan.bansa.counter
 import android.content.Context
 import android.view.View
 import android.widget.LinearLayout
-import com.brianegan.bansa.Action
 import com.brianegan.bansa.Store
 import rx.Subscription
 import rx.android.schedulers.AndroidSchedulers
@@ -13,7 +12,7 @@ import trikita.anvil.Anvil
 import trikita.anvil.DSL.*
 import trikita.anvil.RenderableView
 
-class RootView(c: Context, val store: Store<ApplicationState, Action>) : RenderableView(c) {
+class RootView(c: Context, val store: Store<ApplicationState, Any>) : RenderableView(c) {
     override fun view() {
         template(buildPresentationModel())
     }

--- a/examples/counter/src/main/kotlin/com/brianegan/bansa/counter/counterReducer.kt
+++ b/examples/counter/src/main/kotlin/com/brianegan/bansa/counter/counterReducer.kt
@@ -1,8 +1,6 @@
 package com.brianegan.bansa.counter
 
-import com.brianegan.bansa.Action
-
-val counterReducer = { state: ApplicationState, action: Action ->
+val counterReducer = { state: ApplicationState, action: Any ->
     when (action) {
         is CounterActions.INIT -> state
         is CounterActions.INCREMENT -> state.copy(counter = state.counter.plus(1))

--- a/examples/counterPair/src/main/kotlin/com/brianegan/bansa/counterPair/Application.kt
+++ b/examples/counterPair/src/main/kotlin/com/brianegan/bansa/counterPair/Application.kt
@@ -1,6 +1,5 @@
 package com.brianegan.bansa.counterPair
 
-import com.brianegan.bansa.Action
 import com.brianegan.bansa.Store
 import com.brianegan.bansa.createStore
 import uy.kohesive.injekt.Injekt
@@ -13,12 +12,12 @@ class Application : android.app.Application() {
     companion object : InjektMain() {
         override fun InjektRegistrar.registerInjectables() {
             addSingleton(
-                    fullType<Store<ApplicationState, Action>>(),
+                    fullType<Store<ApplicationState, Any>>(),
                     createStore(ApplicationState(), applicationReducer));
         }
     }
 
-    val store = Injekt.get(fullType<Store<ApplicationState, Action>>())
+    val store = Injekt.get(fullType<Store<ApplicationState, Any>>())
 
     override fun onCreate() {
         super.onCreate()

--- a/examples/counterPair/src/main/kotlin/com/brianegan/bansa/counterPair/ApplicationState.kt
+++ b/examples/counterPair/src/main/kotlin/com/brianegan/bansa/counterPair/ApplicationState.kt
@@ -1,8 +1,7 @@
 package com.brianegan.bansa.counterPair
 
-import com.brianegan.bansa.State
 import java.util.*
 
 data class ApplicationState(val counters: Map<UUID, Int> = linkedMapOf(
         Pair(UUID.randomUUID(), 0),
-        Pair(UUID.randomUUID(), 0))) : State
+        Pair(UUID.randomUUID(), 0)))

--- a/examples/counterPair/src/main/kotlin/com/brianegan/bansa/counterPair/CounterActions.kt
+++ b/examples/counterPair/src/main/kotlin/com/brianegan/bansa/counterPair/CounterActions.kt
@@ -1,9 +1,8 @@
 package com.brianegan.bansa.counterPair
 
-import com.brianegan.bansa.Action
 import java.util.*
 
-interface CounterAction : Action {}
+interface CounterAction
 
 data class INIT(val initialState: ApplicationState = ApplicationState()) : CounterAction
 data class INCREMENT(val id : UUID) : CounterAction

--- a/examples/counterPair/src/main/kotlin/com/brianegan/bansa/counterPair/RootActivity.kt
+++ b/examples/counterPair/src/main/kotlin/com/brianegan/bansa/counterPair/RootActivity.kt
@@ -2,14 +2,13 @@ package com.brianegan.bansa.counterPair
 
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
-import com.brianegan.bansa.Action
 import com.brianegan.bansa.Store
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.fullType
 import uy.kohesive.injekt.api.get
 
 public open class RootActivity : AppCompatActivity() {
-    val store: Store<ApplicationState, Action> = Injekt.get(fullType<Store<ApplicationState, Action>>())
+    val store: Store<ApplicationState, Any> = Injekt.get(fullType<Store<ApplicationState, Any>>())
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState);

--- a/examples/counterPair/src/main/kotlin/com/brianegan/bansa/counterPair/RootView.kt
+++ b/examples/counterPair/src/main/kotlin/com/brianegan/bansa/counterPair/RootView.kt
@@ -3,7 +3,6 @@ package com.brianegan.bansa.counterPair
 import android.content.Context
 import android.view.View
 import android.widget.LinearLayout
-import com.brianegan.bansa.Action
 import com.brianegan.bansa.Store
 import rx.Subscription
 import rx.android.schedulers.AndroidSchedulers
@@ -14,7 +13,7 @@ import trikita.anvil.DSL.*
 import trikita.anvil.RenderableView
 import java.util.*
 
-public class RootView(c: Context, val store: Store<ApplicationState, Action>) : RenderableView(c) {
+public class RootView(c: Context, val store: Store<ApplicationState, Any>) : RenderableView(c) {
     override fun view() {
         linearLayout {
             orientation(LinearLayout.VERTICAL)

--- a/examples/counterPair/src/main/kotlin/com/brianegan/bansa/counterPair/applicationReducer.kt
+++ b/examples/counterPair/src/main/kotlin/com/brianegan/bansa/counterPair/applicationReducer.kt
@@ -1,8 +1,6 @@
 package com.brianegan.bansa.counterPair
 
-import com.brianegan.bansa.Action
-
-val applicationReducer = { state: ApplicationState, action: Action ->
+val applicationReducer = { state: ApplicationState, action: Any ->
     when (action) {
         is CounterAction -> counterReducer(state, action)
         else -> state

--- a/examples/counterPair/src/main/kotlin/com/brianegan/bansa/counterPair/createComponent.kt
+++ b/examples/counterPair/src/main/kotlin/com/brianegan/bansa/counterPair/createComponent.kt
@@ -1,10 +1,9 @@
 package com.brianegan.bansa.counterPair
 
 import com.brianegan.bansa.Action
-import com.brianegan.bansa.State
 import com.brianegan.bansa.Store
 
-fun <A : Action, S : State, VM> connect(
+fun <A : Action, S, VM> connect(
         mapStoreToViewModel: (Store<S, A>) -> VM)
         : ((VM) -> Unit) -> (Store<S, A>) -> Unit {
 

--- a/examples/counterPair/src/main/kotlin/com/brianegan/bansa/counterPair/createComponent.kt
+++ b/examples/counterPair/src/main/kotlin/com/brianegan/bansa/counterPair/createComponent.kt
@@ -1,9 +1,8 @@
 package com.brianegan.bansa.counterPair
 
-import com.brianegan.bansa.Action
 import com.brianegan.bansa.Store
 
-fun <A : Action, S, VM> connect(
+fun <A : Any, S, VM> connect(
         mapStoreToViewModel: (Store<S, A>) -> VM)
         : ((VM) -> Unit) -> (Store<S, A>) -> Unit {
 

--- a/examples/listOfCounters/src/main/kotlin/com/brianegan/bansa/listOfCounters/Application.kt
+++ b/examples/listOfCounters/src/main/kotlin/com/brianegan/bansa/listOfCounters/Application.kt
@@ -1,6 +1,5 @@
 package com.brianegan.bansa.listOfCounters
 
-import com.brianegan.bansa.Action
 import com.brianegan.bansa.Store
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.InjektMain
@@ -12,12 +11,12 @@ class Application : android.app.Application() {
     companion object : InjektMain() {
         override fun InjektRegistrar.registerInjectables() {
             addSingleton(
-                    fullType<Store<ApplicationState, Action>>(),
+                    fullType<Store<ApplicationState, Any>>(),
                     com.brianegan.bansa.createStore(ApplicationState(), applicationReducer));
         }
     }
 
-    val store = Injekt.get(fullType<Store<ApplicationState, Action>>())
+    val store = Injekt.get(fullType<Store<ApplicationState, Any>>())
 
     override fun onCreate() {
         super.onCreate()

--- a/examples/listOfCounters/src/main/kotlin/com/brianegan/bansa/listOfCounters/ApplicationState.kt
+++ b/examples/listOfCounters/src/main/kotlin/com/brianegan/bansa/listOfCounters/ApplicationState.kt
@@ -1,8 +1,7 @@
 package com.brianegan.bansa.listOfCounters
 
-import com.brianegan.bansa.State
 import java.util.*
 
-data class ApplicationState(val counters: List<Counter> = listOf()) : State
+data class ApplicationState(val counters: List<Counter> = listOf())
 
 data class Counter(val id: UUID = UUID.randomUUID(), val value: Int = 0)

--- a/examples/listOfCounters/src/main/kotlin/com/brianegan/bansa/listOfCounters/CounterActions.kt
+++ b/examples/listOfCounters/src/main/kotlin/com/brianegan/bansa/listOfCounters/CounterActions.kt
@@ -1,9 +1,8 @@
 package com.brianegan.bansa.listOfCounters
 
-import com.brianegan.bansa.Action
 import java.util.*
 
-interface CounterAction : Action {}
+interface CounterAction
 
 data class INIT(val state : ApplicationState = ApplicationState()) : CounterAction
 data class ADD(val counter : Counter = Counter()) : CounterAction

--- a/examples/listOfCounters/src/main/kotlin/com/brianegan/bansa/listOfCounters/RootActivity.kt
+++ b/examples/listOfCounters/src/main/kotlin/com/brianegan/bansa/listOfCounters/RootActivity.kt
@@ -2,14 +2,13 @@ package com.brianegan.bansa.listOfCounters
 
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
-import com.brianegan.bansa.Action
 import com.brianegan.bansa.Store
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.fullType
 import uy.kohesive.injekt.api.get
 
 public open class RootActivity : AppCompatActivity() {
-    val store = Injekt.get(fullType<Store<ApplicationState, Action>>())
+    val store = Injekt.get(fullType<Store<ApplicationState, Any>>())
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/examples/listOfCounters/src/main/kotlin/com/brianegan/bansa/listOfCounters/RootView.kt
+++ b/examples/listOfCounters/src/main/kotlin/com/brianegan/bansa/listOfCounters/RootView.kt
@@ -3,7 +3,6 @@ package com.brianegan.bansa.listOfCounters
 import android.content.Context
 import android.view.View
 import android.widget.LinearLayout
-import com.brianegan.bansa.Action
 import com.brianegan.bansa.Store
 import rx.Subscription
 import rx.android.schedulers.AndroidSchedulers
@@ -13,7 +12,7 @@ import trikita.anvil.DSL.*
 import trikita.anvil.RenderableAdapter
 import trikita.anvil.RenderableView
 
-public class RootView(c: Context, val store: Store<ApplicationState, Action>) : RenderableView(c) {
+public class RootView(c: Context, val store: Store<ApplicationState, Any>) : RenderableView(c) {
     val stateChangeSubscription: Subscription = store
             .state
             .observeOn(AndroidSchedulers.mainThread())

--- a/examples/listOfCounters/src/main/kotlin/com/brianegan/bansa/listOfCounters/applicationReducer.kt
+++ b/examples/listOfCounters/src/main/kotlin/com/brianegan/bansa/listOfCounters/applicationReducer.kt
@@ -1,8 +1,6 @@
 package com.brianegan.bansa.listOfCounters
 
-import com.brianegan.bansa.Action
-
-val applicationReducer = { state: ApplicationState, action: Action ->
+val applicationReducer = { state: ApplicationState, action: Any ->
     when (action) {
         is CounterAction -> counterReducer(state, action)
         else -> state

--- a/examples/listOfCounters/src/main/kotlin/com/brianegan/bansa/listOfCounters/counterView.kt
+++ b/examples/listOfCounters/src/main/kotlin/com/brianegan/bansa/listOfCounters/counterView.kt
@@ -2,7 +2,6 @@ package com.brianegan.bansa.listOfCounters
 
 import android.view.View
 import android.widget.LinearLayout
-import com.brianegan.bansa.Action
 import com.brianegan.bansa.Store
 import trikita.anvil.DSL.*
 
@@ -36,7 +35,7 @@ fun counterView(model: CounterViewModel) {
     }
 }
 
-fun buildMapCounterToCounterViewModel(store: Store<ApplicationState, Action>): (Counter) -> CounterViewModel {
+fun buildMapCounterToCounterViewModel(store: Store<ApplicationState, Any>): (Counter) -> CounterViewModel {
     return { counter ->
         val (id, value) = counter
         val increment = View.OnClickListener {

--- a/examples/listOfCounters/src/main/kotlin/com/brianegan/bansa/listOfCounters/createComponent.kt
+++ b/examples/listOfCounters/src/main/kotlin/com/brianegan/bansa/listOfCounters/createComponent.kt
@@ -1,10 +1,9 @@
 package com.brianegan.bansa.listOfCounters
 
 import com.brianegan.bansa.Action
-import com.brianegan.bansa.State
 import com.brianegan.bansa.Store
 
-fun <A : Action, S : State, VM> connect(
+fun <A : Action, S, VM> connect(
         mapStoreToViewModel: (Store<S, A>) -> VM)
         : ((VM) -> Unit) -> (Store<S, A>) -> Unit {
 

--- a/examples/listOfCounters/src/main/kotlin/com/brianegan/bansa/listOfCounters/createComponent.kt
+++ b/examples/listOfCounters/src/main/kotlin/com/brianegan/bansa/listOfCounters/createComponent.kt
@@ -1,9 +1,8 @@
 package com.brianegan.bansa.listOfCounters
 
-import com.brianegan.bansa.Action
 import com.brianegan.bansa.Store
 
-fun <A : Action, S, VM> connect(
+fun <A, S, VM> connect(
         mapStoreToViewModel: (Store<S, A>) -> VM)
         : ((VM) -> Unit) -> (Store<S, A>) -> Unit {
 

--- a/examples/listOfCountersVariant/src/main/kotlin/com/brianegan/bansa/listOfCountersVariant/Application.kt
+++ b/examples/listOfCountersVariant/src/main/kotlin/com/brianegan/bansa/listOfCountersVariant/Application.kt
@@ -1,6 +1,5 @@
 package com.brianegan.bansa.listOfCountersVariant
 
-import com.brianegan.bansa.Action
 import com.brianegan.bansa.Store
 import com.brianegan.bansa.createStore
 import uy.kohesive.injekt.Injekt
@@ -13,12 +12,12 @@ class Application : android.app.Application() {
     companion object : InjektMain() {
         override fun InjektRegistrar.registerInjectables() {
             addSingleton(
-                    fullType<Store<ApplicationState, Action>>(),
+                    fullType<Store<ApplicationState, Any>>(),
                     createStore(ApplicationState(), applicationReducer));
         }
     }
 
-    val store = Injekt.get(fullType<Store<ApplicationState, Action>>())
+    val store = Injekt.get(fullType<Store<ApplicationState, Any>>())
 
     override fun onCreate() {
         super.onCreate()

--- a/examples/listOfCountersVariant/src/main/kotlin/com/brianegan/bansa/listOfCountersVariant/ApplicationState.kt
+++ b/examples/listOfCountersVariant/src/main/kotlin/com/brianegan/bansa/listOfCountersVariant/ApplicationState.kt
@@ -1,10 +1,9 @@
 package com.brianegan.bansa.listOfCountersVariant
 
-import com.brianegan.bansa.State
 import com.github.andrewoma.dexx.kollection.ImmutableList
 import com.github.andrewoma.dexx.kollection.immutableListOf
 import java.util.*
 
-data class ApplicationState(val counters: ImmutableList<Counter> = immutableListOf()) : State
+data class ApplicationState(val counters: ImmutableList<Counter> = immutableListOf())
 
 data class Counter(val id: UUID = UUID.randomUUID(), val value: Int = 0)

--- a/examples/listOfCountersVariant/src/main/kotlin/com/brianegan/bansa/listOfCountersVariant/CounterActions.kt
+++ b/examples/listOfCountersVariant/src/main/kotlin/com/brianegan/bansa/listOfCountersVariant/CounterActions.kt
@@ -1,9 +1,8 @@
 package com.brianegan.bansa.listOfCountersVariant
 
-import com.brianegan.bansa.Action
 import java.util.*
 
-interface CounterAction : Action {}
+interface CounterAction
 
 data class INIT(val state : ApplicationState = ApplicationState()) : CounterAction
 data class ADD(val counter : Counter = Counter()) : CounterAction

--- a/examples/listOfCountersVariant/src/main/kotlin/com/brianegan/bansa/listOfCountersVariant/RootActivity.kt
+++ b/examples/listOfCountersVariant/src/main/kotlin/com/brianegan/bansa/listOfCountersVariant/RootActivity.kt
@@ -2,14 +2,13 @@ package com.brianegan.bansa.listOfCountersVariant
 
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
-import com.brianegan.bansa.Action
 import com.brianegan.bansa.Store
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.fullType
 import uy.kohesive.injekt.api.get
 
 public open class RootActivity : AppCompatActivity() {
-    val store = Injekt.get(fullType<Store<ApplicationState, Action>>())
+    val store = Injekt.get(fullType<Store<ApplicationState, Any>>())
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/examples/listOfCountersVariant/src/main/kotlin/com/brianegan/bansa/listOfCountersVariant/RootView.kt
+++ b/examples/listOfCountersVariant/src/main/kotlin/com/brianegan/bansa/listOfCountersVariant/RootView.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.support.v7.widget.DefaultItemAnimator
 import android.support.v7.widget.LinearLayoutManager
 import android.view.View
-import com.brianegan.bansa.Action
 import com.brianegan.bansa.Store
 import rx.Subscription
 import rx.android.schedulers.AndroidSchedulers
@@ -15,7 +14,7 @@ import trikita.anvil.RenderableView
 import trikita.anvil.recyclerview.Recycler
 import trikita.anvil.recyclerview.Recycler.*
 
-public class RootView(c: Context, val store: Store<ApplicationState, Action>) : RenderableView(c) {
+public class RootView(c: Context, val store: Store<ApplicationState, Any>) : RenderableView(c) {
     val stateChangeSubscription: Subscription = store
             .state
             // Yay! We can easily schedule when we perform view updates as to not

--- a/examples/listOfCountersVariant/src/main/kotlin/com/brianegan/bansa/listOfCountersVariant/applicationReducer.kt
+++ b/examples/listOfCountersVariant/src/main/kotlin/com/brianegan/bansa/listOfCountersVariant/applicationReducer.kt
@@ -1,8 +1,6 @@
 package com.brianegan.bansa.listOfCountersVariant
 
-import com.brianegan.bansa.Action
-
-val applicationReducer = { state: ApplicationState, action: Action ->
+val applicationReducer = { state: ApplicationState, action: Any ->
     when (action) {
         is CounterAction -> counterReducer(state, action)
         else -> state

--- a/examples/listOfCountersVariant/src/main/kotlin/com/brianegan/bansa/listOfCountersVariant/counterView.kt
+++ b/examples/listOfCountersVariant/src/main/kotlin/com/brianegan/bansa/listOfCountersVariant/counterView.kt
@@ -2,7 +2,6 @@ package com.brianegan.bansa.listOfCountersVariant
 
 import android.view.View
 import android.widget.LinearLayout
-import com.brianegan.bansa.Action
 import com.brianegan.bansa.Store
 import trikita.anvil.BaseDSL.R
 import trikita.anvil.DSL.*
@@ -46,7 +45,7 @@ fun counterView(model: CounterViewModel) {
     }
 }
 
-fun buildMapCounterToCounterViewModel(store: Store<ApplicationState, Action>): (Counter) -> CounterViewModel {
+fun buildMapCounterToCounterViewModel(store: Store<ApplicationState, Any>): (Counter) -> CounterViewModel {
     return { counter ->
         val (id) = counter
 

--- a/examples/listOfCountersVariant/src/main/kotlin/com/brianegan/bansa/listOfCountersVariant/createComponent.kt
+++ b/examples/listOfCountersVariant/src/main/kotlin/com/brianegan/bansa/listOfCountersVariant/createComponent.kt
@@ -1,9 +1,8 @@
 package com.brianegan.bansa.listOfCountersVariant
 
-import com.brianegan.bansa.Action
 import com.brianegan.bansa.Store
 
-fun <A : Action, S, VM> connect(
+fun <A, S, VM> connect(
         mapStoreToViewModel: (Store<S, A>) -> VM)
         : ((VM) -> Unit) -> (Store<S, A>) -> Unit {
 

--- a/examples/listOfCountersVariant/src/main/kotlin/com/brianegan/bansa/listOfCountersVariant/createComponent.kt
+++ b/examples/listOfCountersVariant/src/main/kotlin/com/brianegan/bansa/listOfCountersVariant/createComponent.kt
@@ -1,10 +1,9 @@
 package com.brianegan.bansa.listOfCountersVariant
 
 import com.brianegan.bansa.Action
-import com.brianegan.bansa.State
 import com.brianegan.bansa.Store
 
-fun <A : Action, S : State, VM> connect(
+fun <A : Action, S, VM> connect(
         mapStoreToViewModel: (Store<S, A>) -> VM)
         : ((VM) -> Unit) -> (Store<S, A>) -> Unit {
 

--- a/examples/listOfTrendingGifs/src/main/kotlin/com/brianegan/bansa/listOfTrendingGifs/Application.kt
+++ b/examples/listOfTrendingGifs/src/main/kotlin/com/brianegan/bansa/listOfTrendingGifs/Application.kt
@@ -1,6 +1,5 @@
 package com.brianegan.bansa.listOfTrendingGifs
 
-import com.brianegan.bansa.Action
 import com.brianegan.bansa.Store
 import com.brianegan.bansa.applyMiddleware
 import com.brianegan.bansa.createStore
@@ -19,12 +18,12 @@ class Application : android.app.Application() {
     companion object : InjektMain() {
         override fun InjektRegistrar.registerInjectables() {
             addSingleton(
-                    fullType<Store<ApplicationState, Action>>(),
+                    fullType<Store<ApplicationState, Any>>(),
                     applyMiddleware(gifMiddleware, loggingMiddleware)(createStore(ApplicationState(), applicationReducer)));
         }
     }
 
-    val store = Injekt.get(fullType<Store<ApplicationState, Action>>())
+    val store = Injekt.get(fullType<Store<ApplicationState, Any>>())
 
     override fun onCreate() {
         super.onCreate()

--- a/examples/listOfTrendingGifs/src/main/kotlin/com/brianegan/bansa/listOfTrendingGifs/RootActivity.kt
+++ b/examples/listOfTrendingGifs/src/main/kotlin/com/brianegan/bansa/listOfTrendingGifs/RootActivity.kt
@@ -2,7 +2,6 @@ package com.brianegan.bansa.listOfTrendingGifs
 
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
-import com.brianegan.bansa.Action
 import com.brianegan.bansa.Store
 import com.brianegan.bansa.listOfTrendingGifs.state.ApplicationState
 import uy.kohesive.injekt.Injekt
@@ -10,7 +9,7 @@ import uy.kohesive.injekt.api.fullType
 import uy.kohesive.injekt.api.get
 
 class RootActivity : AppCompatActivity() {
-    val store = Injekt.get(fullType<Store<ApplicationState, Action>>())
+    val store = Injekt.get(fullType<Store<ApplicationState, Any>>())
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/examples/listOfTrendingGifs/src/main/kotlin/com/brianegan/bansa/listOfTrendingGifs/RootView.kt
+++ b/examples/listOfTrendingGifs/src/main/kotlin/com/brianegan/bansa/listOfTrendingGifs/RootView.kt
@@ -1,7 +1,6 @@
 package com.brianegan.bansa.listOfTrendingGifs
 
 import android.content.Context
-import com.brianegan.bansa.Action
 import com.brianegan.bansa.Store
 import com.brianegan.bansa.listOfTrendingGifs.actions.FETCH_NEXT_PAGE
 import com.brianegan.bansa.listOfTrendingGifs.actions.REFRESH
@@ -19,7 +18,7 @@ import trikita.anvil.Anvil
 import trikita.anvil.DSL.*
 import trikita.anvil.RenderableView
 
-class RootView(c: Context, val store: Store<ApplicationState, Action>) : RenderableView(c) {
+class RootView(c: Context, val store: Store<ApplicationState, Any>) : RenderableView(c) {
     override fun view() {
         swipeRefreshLayout {
             onRefresh { store.dispatch(REFRESH) }

--- a/examples/listOfTrendingGifs/src/main/kotlin/com/brianegan/bansa/listOfTrendingGifs/actions/AppActions.kt
+++ b/examples/listOfTrendingGifs/src/main/kotlin/com/brianegan/bansa/listOfTrendingGifs/actions/AppActions.kt
@@ -1,10 +1,9 @@
 package com.brianegan.bansa.listOfTrendingGifs.actions
 
-import com.brianegan.bansa.Action
 import com.brianegan.bansa.listOfTrendingGifs.models.TrendingGifs
 import rx.Subscription
 
-interface AppAction : Action {}
+interface AppAction
 
 object INIT : AppAction
 object REFRESH : AppAction

--- a/examples/listOfTrendingGifs/src/main/kotlin/com/brianegan/bansa/listOfTrendingGifs/middleware/createMiddleware.kt
+++ b/examples/listOfTrendingGifs/src/main/kotlin/com/brianegan/bansa/listOfTrendingGifs/middleware/createMiddleware.kt
@@ -1,10 +1,9 @@
 package com.brianegan.bansa.listOfTrendingGifs.middleware
 
 import com.brianegan.bansa.Action
-import com.brianegan.bansa.State
 import com.brianegan.bansa.Store
 
-fun <S : State, A : Action>createMiddleware(middleware: (Store<S, A>, (A) -> A, A) -> A)
+fun <S, A : Action>createMiddleware(middleware: (Store<S, A>, (A) -> A, A) -> A)
         : (Store<S, A>) -> ((A) -> A) -> (A) -> A {
     return { store: Store<S, A> ->
         { next: (A) -> A ->

--- a/examples/listOfTrendingGifs/src/main/kotlin/com/brianegan/bansa/listOfTrendingGifs/middleware/createMiddleware.kt
+++ b/examples/listOfTrendingGifs/src/main/kotlin/com/brianegan/bansa/listOfTrendingGifs/middleware/createMiddleware.kt
@@ -1,9 +1,8 @@
 package com.brianegan.bansa.listOfTrendingGifs.middleware
 
-import com.brianegan.bansa.Action
 import com.brianegan.bansa.Store
 
-fun <S, A : Action>createMiddleware(middleware: (Store<S, A>, (A) -> A, A) -> A)
+fun <S, A>createMiddleware(middleware: (Store<S, A>, (A) -> A, A) -> A)
         : (Store<S, A>) -> ((A) -> A) -> (A) -> A {
     return { store: Store<S, A> ->
         { next: (A) -> A ->

--- a/examples/listOfTrendingGifs/src/main/kotlin/com/brianegan/bansa/listOfTrendingGifs/middleware/gifMiddleware.kt
+++ b/examples/listOfTrendingGifs/src/main/kotlin/com/brianegan/bansa/listOfTrendingGifs/middleware/gifMiddleware.kt
@@ -1,12 +1,10 @@
 package com.brianegan.bansa.listOfTrendingGifs.middleware
 
-import com.brianegan.bansa.Action
-import com.brianegan.bansa.listOfTrendingGifs.*
 import com.brianegan.bansa.listOfTrendingGifs.actions.*
 import com.brianegan.bansa.listOfTrendingGifs.api.fetchTrendingGifs
 import com.brianegan.bansa.listOfTrendingGifs.state.ApplicationState
 
-val gifMiddleware = createMiddleware<ApplicationState, Action> { store, next, action ->
+val gifMiddleware = createMiddleware<ApplicationState, Any> { store, next, action ->
     val state = store.getState()
 
     when (action) {

--- a/examples/listOfTrendingGifs/src/main/kotlin/com/brianegan/bansa/listOfTrendingGifs/middleware/loggingMiddleware.kt
+++ b/examples/listOfTrendingGifs/src/main/kotlin/com/brianegan/bansa/listOfTrendingGifs/middleware/loggingMiddleware.kt
@@ -1,9 +1,8 @@
 package com.brianegan.bansa.listOfTrendingGifs.middleware
 
-import com.brianegan.bansa.Action
 import com.brianegan.bansa.listOfTrendingGifs.state.ApplicationState
 
-val loggingMiddleware = createMiddleware<ApplicationState, Action> { store, next, action ->
+val loggingMiddleware = createMiddleware<ApplicationState, Any> { store, next, action ->
     println("Before ${action.toString()}: ${store.getState()}")
     next(action)
     println("After ${action.toString()}:  ${store.getState()}")

--- a/examples/listOfTrendingGifs/src/main/kotlin/com/brianegan/bansa/listOfTrendingGifs/reducers/applicationReducer.kt
+++ b/examples/listOfTrendingGifs/src/main/kotlin/com/brianegan/bansa/listOfTrendingGifs/reducers/applicationReducer.kt
@@ -1,12 +1,11 @@
 package com.brianegan.bansa.listOfTrendingGifs.reducers
 
-import com.brianegan.bansa.Action
 import com.brianegan.bansa.listOfTrendingGifs.actions.*
 import com.brianegan.bansa.listOfTrendingGifs.api.NextPage
 import com.brianegan.bansa.listOfTrendingGifs.state.ApplicationState
 import rx.subscriptions.Subscriptions
 
-val applicationReducer = { state: ApplicationState, action: Action ->
+val applicationReducer = { state: ApplicationState, action: Any ->
     when (action) {
         is INIT -> ApplicationState()
 

--- a/examples/listOfTrendingGifs/src/main/kotlin/com/brianegan/bansa/listOfTrendingGifs/state/ApplicationState.kt
+++ b/examples/listOfTrendingGifs/src/main/kotlin/com/brianegan/bansa/listOfTrendingGifs/state/ApplicationState.kt
@@ -1,8 +1,7 @@
 package com.brianegan.bansa.listOfTrendingGifs.state
 
-import com.brianegan.bansa.State
-import com.brianegan.bansa.listOfTrendingGifs.models.Gif
 import com.brianegan.bansa.listOfTrendingGifs.api.NextPage
+import com.brianegan.bansa.listOfTrendingGifs.models.Gif
 import rx.Subscription
 import rx.subscriptions.Subscriptions
 
@@ -10,4 +9,4 @@ data class ApplicationState(val isRefreshing: Boolean = true,
                             val isFetching: Boolean = false,
                             val gifs: List<Gif> = listOf(),
                             val pagination: NextPage = NextPage(),
-                            val currentRequest: Subscription = Subscriptions.empty()) : State
+                            val currentRequest: Subscription = Subscriptions.empty())

--- a/examples/randomGif/src/main/kotlin/com/brianegan/bansa/randomGif/AppActions.kt
+++ b/examples/randomGif/src/main/kotlin/com/brianegan/bansa/randomGif/AppActions.kt
@@ -1,8 +1,6 @@
 package com.brianegan.bansa.randomGif
 
-import com.brianegan.bansa.Action
-
-interface AppAction : Action {}
+interface AppAction
 
 object INIT : AppAction
 object FETCHING : AppAction

--- a/examples/randomGif/src/main/kotlin/com/brianegan/bansa/randomGif/Application.kt
+++ b/examples/randomGif/src/main/kotlin/com/brianegan/bansa/randomGif/Application.kt
@@ -1,6 +1,5 @@
 package com.brianegan.bansa.randomGif
 
-import com.brianegan.bansa.Action
 import com.brianegan.bansa.Store
 import com.brianegan.bansa.applyMiddleware
 import com.brianegan.bansa.createStore
@@ -14,12 +13,12 @@ class Application : android.app.Application() {
     companion object : InjektMain() {
         override fun InjektRegistrar.registerInjectables() {
             addSingleton(
-                    fullType<Store<ApplicationState, Action>>(),
+                    fullType<Store<ApplicationState, Any>>(),
                     (applyMiddleware(gifMiddleware))(createStore(ApplicationState(), applicationReducer)));
         }
     }
 
-    val store = Injekt.get<Store<ApplicationState, Action>>()
+    val store = Injekt.get<Store<ApplicationState, Any>>()
 
     override fun onCreate() {
         super.onCreate()

--- a/examples/randomGif/src/main/kotlin/com/brianegan/bansa/randomGif/ApplicationState.kt
+++ b/examples/randomGif/src/main/kotlin/com/brianegan/bansa/randomGif/ApplicationState.kt
@@ -1,5 +1,3 @@
 package com.brianegan.bansa.randomGif
 
-import com.brianegan.bansa.State
-
-data class ApplicationState(val isFetching: Boolean = true, val videoUrl: String = "") : State
+data class ApplicationState(val isFetching: Boolean = true, val videoUrl: String = "")

--- a/examples/randomGif/src/main/kotlin/com/brianegan/bansa/randomGif/RootActivity.kt
+++ b/examples/randomGif/src/main/kotlin/com/brianegan/bansa/randomGif/RootActivity.kt
@@ -2,13 +2,12 @@ package com.brianegan.bansa.randomGif
 
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
-import com.brianegan.bansa.Action
 import com.brianegan.bansa.Store
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
 class RootActivity : AppCompatActivity() {
-    val store = Injekt.get<Store<ApplicationState, Action>>()
+    val store = Injekt.get<Store<ApplicationState, Any>>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/examples/randomGif/src/main/kotlin/com/brianegan/bansa/randomGif/RootView.kt
+++ b/examples/randomGif/src/main/kotlin/com/brianegan/bansa/randomGif/RootView.kt
@@ -6,7 +6,6 @@ import android.net.Uri
 import android.view.View
 import android.widget.LinearLayout
 import android.widget.VideoView
-import com.brianegan.bansa.Action
 import com.brianegan.bansa.Store
 import rx.Subscription
 import rx.android.schedulers.AndroidSchedulers
@@ -16,7 +15,7 @@ import trikita.anvil.Anvil
 import trikita.anvil.DSL.*
 import trikita.anvil.RenderableView
 
-public class RootView(c: Context, val store: Store<ApplicationState, Action>) : RenderableView(c) {
+public class RootView(c: Context, val store: Store<ApplicationState, Any>) : RenderableView(c) {
     override fun view() {
         template(buildViewModel())
     }

--- a/examples/randomGif/src/main/kotlin/com/brianegan/bansa/randomGif/appReducer.kt
+++ b/examples/randomGif/src/main/kotlin/com/brianegan/bansa/randomGif/appReducer.kt
@@ -1,8 +1,6 @@
 package com.brianegan.bansa.randomGif
 
-import com.brianegan.bansa.Action
-
-val applicationReducer = { state: ApplicationState, action: Action ->
+val applicationReducer = { state: ApplicationState, action: Any ->
     when (action) {
         is INIT -> ApplicationState()
         is FETCHING -> state.copy(isFetching = true)

--- a/examples/randomGif/src/main/kotlin/com/brianegan/bansa/randomGif/gifMiddleware.kt
+++ b/examples/randomGif/src/main/kotlin/com/brianegan/bansa/randomGif/gifMiddleware.kt
@@ -1,11 +1,10 @@
 package com.brianegan.bansa.randomGif
 
-import com.brianegan.bansa.Action
 import com.brianegan.bansa.Store
 
-val gifMiddleware = { store: Store<ApplicationState, Action> ->
-    { next: (Action) -> Action ->
-        { action: Action ->
+val gifMiddleware = { store: Store<ApplicationState, Any> ->
+    { next: (Any) -> Any ->
+        { action: Any ->
             when (action) {
                 is FETCH_RANDOM_GIF -> {
                     next(FETCHING)


### PR DESCRIPTION
Hi again,

I removed the State and Action interfaces, they're useless until they remains empty. Generics are enough to get type safety. Also, users may not understand why they would have to implement empty interfaces.

What do you think?