### PR TITLE
Rename state props

### DIFF
--- a/bansa/src/main/kotlin/com/brianegan/bansa/RxStore.kt
+++ b/bansa/src/main/kotlin/com/brianegan/bansa/RxStore.kt
@@ -16,20 +16,20 @@ class RxStore<S, A>(
     private val dispatcher: SerializedSubject<A, A>
     private var currentState: S
 
-    override val state: Observable<S>
+    override val stateChanges: Observable<S>
     var reducer: (S, A) -> S
 
     init {
         reducer = initialReducer
         currentState = initialState
         dispatcher = SerializedSubject<A, A>(PublishSubject.create<A>())
-        state = dispatcher // When an action is dispatched
+        stateChanges = dispatcher // When an action is dispatched
                 .observeOn(scheduler) // Run the scan on a given thread, by default a background thread
                 .scan(currentState, { state, action -> reducer(state, action) }) // Run the action through your reducers, producing a new state
                 .doOnNext({ newState -> currentState = newState }) // Update the state field of the instance for lazy access
                 .share() // Share the Observable so all subscribers receive the same values
 
-        state.subscribe()
+        stateChanges.subscribe()
     }
 
     override fun getState(): S = currentState
@@ -40,6 +40,6 @@ class RxStore<S, A>(
     }
 
     override fun subscribe(subscriber: Subscriber<S>): Subscription {
-        return state.subscribe(subscriber)
+        return stateChanges.subscribe(subscriber)
     }
 }

--- a/bansa/src/main/kotlin/com/brianegan/bansa/Store.kt
+++ b/bansa/src/main/kotlin/com/brianegan/bansa/Store.kt
@@ -5,7 +5,7 @@ import rx.Subscriber
 import rx.Subscription
 
 interface Store<S, A> {
-    val state: Observable<S>
+    val stateChanges: Observable<S>
     fun getState(): S
     var dispatch: (action: A) -> A
     fun subscribe(subscriber: Subscriber<S>): Subscription

--- a/bansa/src/main/kotlin/com/brianegan/bansa/Store.kt
+++ b/bansa/src/main/kotlin/com/brianegan/bansa/Store.kt
@@ -6,7 +6,7 @@ import rx.Subscription
 
 interface Store<S, A> {
     val stateChanges: Observable<S>
-    fun getState(): S
+    val state: S
     var dispatch: (action: A) -> A
     fun subscribe(subscriber: Subscriber<S>): Subscription
 }

--- a/bansa/src/test/kotlin/com/brianegan/bansa/MiddlewareTest.kt
+++ b/bansa/src/test/kotlin/com/brianegan/bansa/MiddlewareTest.kt
@@ -31,7 +31,7 @@ class MiddlewareTest {
 
         store.dispatch(MyAction(type = "hey hey!"))
 
-        assertThat(store.getState()).isEqualTo(MyState())
+        assertThat(store.state).isEqualTo(MyState())
         assertThat(counter).isEqualTo(1)
     }
 
@@ -74,7 +74,7 @@ class MiddlewareTest {
 
         store.dispatch(MyAction(type = "hey hey!"))
 
-        assertThat(store.getState()).isEqualTo(MyState("howdy!"))
+        assertThat(store.state).isEqualTo(MyState("howdy!"))
         assertThat(counter).isEqualTo(2)
         assertThat(order).isEqualTo(arrayListOf("first", "second", "third"))
     }
@@ -131,12 +131,12 @@ class MiddlewareTest {
 
         assertThat(counter).isEqualTo(3)
         assertThat(order).isEqualTo(arrayListOf("FETCHING", "CALL_API"))
-        assertThat(store.getState()).isEqualTo(MyState("FETCHING"))
+        assertThat(store.state).isEqualTo(MyState("FETCHING"))
 
         testScheduler.advanceTimeBy(2L, TimeUnit.SECONDS)
         assertThat(counter).isEqualTo(4)
         assertThat(order).isEqualTo(arrayListOf("FETCHING", "CALL_API", "FETCH_COMPLETE"))
-        assertThat(store.getState()).isEqualTo(MyState(state = "FETCH_COMPLETE"))
+        assertThat(store.state).isEqualTo(MyState(state = "FETCH_COMPLETE"))
     }
 
     @Test

--- a/bansa/src/test/kotlin/com/brianegan/bansa/StoreTest.kt
+++ b/bansa/src/test/kotlin/com/brianegan/bansa/StoreTest.kt
@@ -20,7 +20,7 @@ class StoreTest {
 
         store.dispatch(MyAction(type = "to reduce"))
 
-        assertThat(store.getState().state).isEqualTo("reduced")
+        assertThat(store.state.state).isEqualTo("reduced")
     }
 
     @Test
@@ -45,9 +45,9 @@ class StoreTest {
         val store = createTestStore(MyState(), combineReducers(reducer1, reducer2))
 
         store.dispatch(MyAction(type = helloReducer1))
-        assertThat(store.getState().state).isEqualTo("oh hai")
+        assertThat(store.state.state).isEqualTo("oh hai")
         store.dispatch(MyAction(type = helloReducer2))
-        assertThat(store.getState().state).isEqualTo("mark")
+        assertThat(store.state.state).isEqualTo("mark")
     }
 
     @Test

--- a/examples/counter/src/main/kotlin/com/brianegan/bansa/counter/RootView.kt
+++ b/examples/counter/src/main/kotlin/com/brianegan/bansa/counter/RootView.kt
@@ -26,7 +26,7 @@ class RootView(c: Context, val store: Store<ApplicationState, Any>) : Renderable
     }
 
     private fun buildPresentationModel(): ViewModel {
-        val counter = store.getState().counter
+        val counter = store.state.counter
 
         return ViewModel(counter, increment, decrement)
     }

--- a/examples/counter/src/main/kotlin/com/brianegan/bansa/counter/RootView.kt
+++ b/examples/counter/src/main/kotlin/com/brianegan/bansa/counter/RootView.kt
@@ -63,7 +63,7 @@ class RootView(c: Context, val store: Store<ApplicationState, Any>) : Renderable
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
 
-        subscription = store.state.observeOn(AndroidSchedulers.mainThread()).subscribe(Action1 {
+        subscription = store.stateChanges.observeOn(AndroidSchedulers.mainThread()).subscribe(Action1 {
             Anvil.render()
         })
     }

--- a/examples/counter/src/test/kotlin/com/brianegan/bansa/counter/CounterReducerTest.kt
+++ b/examples/counter/src/test/kotlin/com/brianegan/bansa/counter/CounterReducerTest.kt
@@ -11,21 +11,21 @@ class CounterReducerTest {
         val store = createTestStore()
         store.dispatch(CounterActions.INIT)
 
-        assertThat(store.getState()).isEqualTo(ApplicationState())
+        assertThat(store.state).isEqualTo(ApplicationState())
     }
 
     @Test fun `INCREMENT action should increment the counter state`() {
         val store = createTestStore()
         store.dispatch(CounterActions.INCREMENT)
 
-        assertThat(store.getState()).isEqualTo(ApplicationState(1))
+        assertThat(store.state).isEqualTo(ApplicationState(1))
     }
 
     @Test fun `DECREMENT action should decrement the counter state`() {
         val store = createTestStore()
         store.dispatch(CounterActions.DECREMENT)
 
-        assertThat(store.getState()).isEqualTo(ApplicationState(-1))
+        assertThat(store.state).isEqualTo(ApplicationState(-1))
     }
 
     fun createTestStore(): Store<ApplicationState, CounterAction> =

--- a/examples/counterPair/src/main/kotlin/com/brianegan/bansa/counterPair/RootView.kt
+++ b/examples/counterPair/src/main/kotlin/com/brianegan/bansa/counterPair/RootView.kt
@@ -18,14 +18,14 @@ public class RootView(c: Context, val store: Store<ApplicationState, Any>) : Ren
         linearLayout {
             orientation(LinearLayout.VERTICAL)
 
-            store.getState().counters.keys.forEach { id ->
+            store.state.counters.keys.forEach { id ->
                 template(buildPresentationModel(id))
             }
         }
     }
 
     private fun buildPresentationModel(id: UUID): ViewModel {
-        val counter = store.getState().counters[id]!!
+        val counter = store.state.counters[id]!!
         val increment = View.OnClickListener {
             store.dispatch(INCREMENT(id))
         }

--- a/examples/counterPair/src/main/kotlin/com/brianegan/bansa/counterPair/RootView.kt
+++ b/examples/counterPair/src/main/kotlin/com/brianegan/bansa/counterPair/RootView.kt
@@ -69,7 +69,7 @@ public class RootView(c: Context, val store: Store<ApplicationState, Any>) : Ren
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
 
-        subscription = store.state.observeOn(AndroidSchedulers.mainThread()).subscribe(Action1 {
+        subscription = store.stateChanges.observeOn(AndroidSchedulers.mainThread()).subscribe(Action1 {
             Anvil.render()
         })
     }

--- a/examples/counterPair/src/test/kotlin/com/brianegan/bansa/counterPair/CounterPairReducerTest.kt
+++ b/examples/counterPair/src/test/kotlin/com/brianegan/bansa/counterPair/CounterPairReducerTest.kt
@@ -13,7 +13,7 @@ class CounterPairReducerTest {
         val store = createTestStore()
         store.dispatch(INIT(applicationState))
 
-        assertThat(store.getState()).isEqualTo(applicationState)
+        assertThat(store.state).isEqualTo(applicationState)
     }
 
     @Test fun shouldIncrementTheCounter() {
@@ -21,7 +21,7 @@ class CounterPairReducerTest {
         val store = createTestStore(createTestState(firstCounter))
         store.dispatch(INCREMENT(firstCounter.first))
 
-        assertThat(store.getState().counters[firstCounter.first]).isEqualTo(1)
+        assertThat(store.state.counters[firstCounter.first]).isEqualTo(1)
     }
 
     @Test fun shouldDecrementTheCounter() {
@@ -29,7 +29,7 @@ class CounterPairReducerTest {
         val store = createTestStore(createTestState(firstCounter))
         store.dispatch(DECREMENT(firstCounter.first))
 
-        assertThat(store.getState().counters[firstCounter.first]).isEqualTo(4)
+        assertThat(store.state.counters[firstCounter.first]).isEqualTo(4)
     }
 
     fun createTestStore(applicationState: ApplicationState = ApplicationState()): Store<ApplicationState, CounterAction> {

--- a/examples/listOfCounters/src/main/kotlin/com/brianegan/bansa/listOfCounters/RootView.kt
+++ b/examples/listOfCounters/src/main/kotlin/com/brianegan/bansa/listOfCounters/RootView.kt
@@ -14,7 +14,7 @@ import trikita.anvil.RenderableView
 
 public class RootView(c: Context, val store: Store<ApplicationState, Any>) : RenderableView(c) {
     val stateChangeSubscription: Subscription = store
-            .state
+            .stateChanges
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe(Action1 { Anvil.render() })
 

--- a/examples/listOfCounters/src/main/kotlin/com/brianegan/bansa/listOfCounters/RootView.kt
+++ b/examples/listOfCounters/src/main/kotlin/com/brianegan/bansa/listOfCounters/RootView.kt
@@ -69,7 +69,7 @@ public class RootView(c: Context, val store: Store<ApplicationState, Any>) : Ren
             listView {
                 margin(dip(0), dip(50), dip(0), dip(0))
                 size(FILL, FILL)
-                adapter(adapter.update(store.getState().counters))
+                adapter(adapter.update(store.state.counters))
             }
         }
     }

--- a/examples/listOfCounters/src/test/kotlin/com/brianegan/bansa/listOfCounters/CounterReducerTest.kt
+++ b/examples/listOfCounters/src/test/kotlin/com/brianegan/bansa/listOfCounters/CounterReducerTest.kt
@@ -15,7 +15,7 @@ class CounterListReducerTest : Spek() { init {
             store.dispatch(INIT(initialState))
 
             it("should initialize the app with a given state") {
-                assertThat(store.getState()).isEqualTo(initialState)
+                assertThat(store.state).isEqualTo(initialState)
             }
         }
     }
@@ -29,7 +29,7 @@ class CounterListReducerTest : Spek() { init {
             store.dispatch(INCREMENT(counter.id))
 
             it("should increase the value of the counter by 1") {
-                assertThat(store.getState().counters.first().value).isEqualTo(1)
+                assertThat(store.state.counters.first().value).isEqualTo(1)
             }
         }
     }
@@ -43,7 +43,7 @@ class CounterListReducerTest : Spek() { init {
             store.dispatch(DECREMENT(counter.id))
 
             it("should decrease the value of the counter by 1") {
-                assertThat(store.getState().counters.first().value).isEqualTo(-1)
+                assertThat(store.state.counters.first().value).isEqualTo(-1)
             }
         }
     }
@@ -61,8 +61,8 @@ class CounterListReducerTest : Spek() { init {
             store.dispatch(ADD(counter4))
 
             it("should append the counter to the end of the list") {
-                assertThat(store.getState().counters.size).isEqualTo(4)
-                assertThat(store.getState().counters.last()).isEqualTo(counter4)
+                assertThat(store.state.counters.size).isEqualTo(4)
+                assertThat(store.state.counters.last()).isEqualTo(counter4)
             }
         }
     }
@@ -79,7 +79,7 @@ class CounterListReducerTest : Spek() { init {
             store.dispatch(REMOVE)
 
             it("should remove the counter from the end of the list") {
-                assertThat(store.getState().counters.size).isEqualTo(2)
+                assertThat(store.state.counters.size).isEqualTo(2)
             }
         }
     }

--- a/examples/listOfCountersVariant/src/main/kotlin/com/brianegan/bansa/listOfCountersVariant/RootView.kt
+++ b/examples/listOfCountersVariant/src/main/kotlin/com/brianegan/bansa/listOfCountersVariant/RootView.kt
@@ -66,7 +66,7 @@ public class RootView(c: Context, val store: Store<ApplicationState, Any>) : Ren
                     size(FILL, FILL)
                 }
 
-                Recycler.adapter(adapter.update(store.getState().counters))
+                Recycler.adapter(adapter.update(store.state.counters))
             }
         }
     }

--- a/examples/listOfCountersVariant/src/main/kotlin/com/brianegan/bansa/listOfCountersVariant/RootView.kt
+++ b/examples/listOfCountersVariant/src/main/kotlin/com/brianegan/bansa/listOfCountersVariant/RootView.kt
@@ -16,7 +16,7 @@ import trikita.anvil.recyclerview.Recycler.*
 
 public class RootView(c: Context, val store: Store<ApplicationState, Any>) : RenderableView(c) {
     val stateChangeSubscription: Subscription = store
-            .state
+            .stateChanges
             // Yay! We can easily schedule when we perform view updates as to not
             // cause too much churn on the view layer in response to rapid state changes,
             // which could diminish app performance

--- a/examples/listOfCountersVariant/src/test/kotlin/com/brianegan/bansa/listOfCountersVariant/CounterReducerTest.kt
+++ b/examples/listOfCountersVariant/src/test/kotlin/com/brianegan/bansa/listOfCountersVariant/CounterReducerTest.kt
@@ -16,7 +16,7 @@ class CounterListVariantReducerTest: Spek() { init {
             store.dispatch(INIT(initialState))
 
             it("should initialize the app with a given state") {
-                assertThat(store.getState()).isEqualTo(initialState)
+                assertThat(store.state).isEqualTo(initialState)
             }
         }
     }
@@ -30,7 +30,7 @@ class CounterListVariantReducerTest: Spek() { init {
             store.dispatch(INCREMENT(counter.id))
 
             it("should increase the value of the counter by 1") {
-                assertThat(store.getState().counters.first().value).isEqualTo(1)
+                assertThat(store.state.counters.first().value).isEqualTo(1)
             }
         }
     }
@@ -44,7 +44,7 @@ class CounterListVariantReducerTest: Spek() { init {
             store.dispatch(DECREMENT(counter.id))
 
             it("should decrease the value of the counter by 1") {
-                assertThat(store.getState().counters.first().value).isEqualTo(-1)
+                assertThat(store.state.counters.first().value).isEqualTo(-1)
             }
         }
     }
@@ -62,8 +62,8 @@ class CounterListVariantReducerTest: Spek() { init {
             store.dispatch(ADD(counter4))
 
             it("should append the counter to the end of the list") {
-                assertThat(store.getState().counters.size).isEqualTo(4)
-                assertThat(store.getState().counters.last()).isEqualTo(counter4)
+                assertThat(store.state.counters.size).isEqualTo(4)
+                assertThat(store.state.counters.last()).isEqualTo(counter4)
             }
         }
     }
@@ -80,8 +80,8 @@ class CounterListVariantReducerTest: Spek() { init {
             store.dispatch(REMOVE(counter2.id))
 
             it("should remove the given counter from the list") {
-                assertThat(store.getState().counters.size).isEqualTo(2)
-                assertThat(store.getState().counters.contains(counter2)).isFalse()
+                assertThat(store.state.counters.size).isEqualTo(2)
+                assertThat(store.state.counters.contains(counter2)).isFalse()
             }
         }
     }

--- a/examples/listOfTrendingGifs/src/main/kotlin/com/brianegan/bansa/listOfTrendingGifs/RootView.kt
+++ b/examples/listOfTrendingGifs/src/main/kotlin/com/brianegan/bansa/listOfTrendingGifs/RootView.kt
@@ -22,12 +22,12 @@ class RootView(c: Context, val store: Store<ApplicationState, Any>) : Renderable
     override fun view() {
         swipeRefreshLayout {
             onRefresh { store.dispatch(REFRESH) }
-            refreshing(store.getState().isRefreshing)
+            refreshing(store.state.isRefreshing)
 
             listView {
                 size(FILL, FILL)
                 dividerHeight(0)
-                adapter(adapter.update(store.getState().gifs))
+                adapter(adapter.update(store.state.gifs))
                 onScroll(fetchMoreGifsAtEndOfListListener)
             }
         }
@@ -36,13 +36,13 @@ class RootView(c: Context, val store: Store<ApplicationState, Any>) : Renderable
     val identity = { it: Gif -> it }
 
     val adapter: BansaAdapter<Gif, Gif> = BansaAdapter(
-            store.getState().gifs,
+            store.state.gifs,
             identity,
             ::gifView
     )
 
     val fetchMoreGifsAtEndOfListListener = OnScrolledToEndOfListListener(
-            { store.getState().isFetching.not() },
+            { store.state.isFetching.not() },
             { store.dispatch(FETCH_NEXT_PAGE) })
 
     var subscription: Subscription = Subscriptions.empty()

--- a/examples/listOfTrendingGifs/src/main/kotlin/com/brianegan/bansa/listOfTrendingGifs/RootView.kt
+++ b/examples/listOfTrendingGifs/src/main/kotlin/com/brianegan/bansa/listOfTrendingGifs/RootView.kt
@@ -52,7 +52,7 @@ class RootView(c: Context, val store: Store<ApplicationState, Any>) : Renderable
 
         store.dispatch(REFRESH)
 
-        subscription = store.state.observeOn(AndroidSchedulers.mainThread()).subscribe(Action1 {
+        subscription = store.stateChanges.observeOn(AndroidSchedulers.mainThread()).subscribe(Action1 {
             Anvil.render()
         })
     }

--- a/examples/listOfTrendingGifs/src/main/kotlin/com/brianegan/bansa/listOfTrendingGifs/middleware/gifMiddleware.kt
+++ b/examples/listOfTrendingGifs/src/main/kotlin/com/brianegan/bansa/listOfTrendingGifs/middleware/gifMiddleware.kt
@@ -5,7 +5,7 @@ import com.brianegan.bansa.listOfTrendingGifs.api.fetchTrendingGifs
 import com.brianegan.bansa.listOfTrendingGifs.state.ApplicationState
 
 val gifMiddleware = createMiddleware<ApplicationState, Any> { store, next, action ->
-    val state = store.getState()
+    val state = store.state
 
     when (action) {
         is FETCH_NEXT_PAGE -> {

--- a/examples/listOfTrendingGifs/src/main/kotlin/com/brianegan/bansa/listOfTrendingGifs/middleware/loggingMiddleware.kt
+++ b/examples/listOfTrendingGifs/src/main/kotlin/com/brianegan/bansa/listOfTrendingGifs/middleware/loggingMiddleware.kt
@@ -3,8 +3,8 @@ package com.brianegan.bansa.listOfTrendingGifs.middleware
 import com.brianegan.bansa.listOfTrendingGifs.state.ApplicationState
 
 val loggingMiddleware = createMiddleware<ApplicationState, Any> { store, next, action ->
-    println("Before ${action.toString()}: ${store.getState()}")
+    println("Before ${action.toString()}: ${store.state}")
     next(action)
-    println("After ${action.toString()}:  ${store.getState()}")
+    println("After ${action.toString()}:  ${store.state}")
     action
 }

--- a/examples/randomGif/src/main/kotlin/com/brianegan/bansa/randomGif/RootView.kt
+++ b/examples/randomGif/src/main/kotlin/com/brianegan/bansa/randomGif/RootView.kt
@@ -25,7 +25,7 @@ public class RootView(c: Context, val store: Store<ApplicationState, Any>) : Ren
     }
 
     private fun buildViewModel(): ViewModel {
-        val (isFetching, videoUrl) = store.getState()
+        val (isFetching, videoUrl) = store.state
 
         return ViewModel(videoUrl, isFetching, fetchRandomGif)
     }

--- a/examples/randomGif/src/main/kotlin/com/brianegan/bansa/randomGif/RootView.kt
+++ b/examples/randomGif/src/main/kotlin/com/brianegan/bansa/randomGif/RootView.kt
@@ -90,7 +90,7 @@ public class RootView(c: Context, val store: Store<ApplicationState, Any>) : Ren
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
 
-        subscription = store.state.observeOn(AndroidSchedulers.mainThread()).subscribe(Action1 {
+        subscription = store.stateChanges.observeOn(AndroidSchedulers.mainThread()).subscribe(Action1 {
             Anvil.render()
         })
     }


### PR DESCRIPTION
I modified the Store interface a little so it is more conventional with usual Kotlin design.

The `getState()` method is not appropriate because it is a getter, and in Kotlin we use properties instead. 

A property is a combination of a implicit getter and a backing field, so explicit getters like `getState()` are not required anymore. Also, there was a property named `state` so the Kotlin compiler would generate a `getState()` function for this property that clashes with the other `getState()` method you created. As a consequence, Java users would not be able to use your `getState()` because they generated `getState()` replaces it.

To summarize:
```
fun getState()  →  val state
val state       →  val stateChanges
```